### PR TITLE
refine tomer gabel's abstract

### DIFF
--- a/_includes/devopsdays/2021-agenda-Day2.html
+++ b/_includes/devopsdays/2021-agenda-Day2.html
@@ -991,33 +991,20 @@
                             alone a decade or two: the same technologies that enable SaaS have also radically
                             transformed on-prem deployment. Modern tools like Docker, Consul, ELK and Kubernetes -
                             to name a few - can be leveraged to completely transform the experience for both
-                            customers and vendors. In this talk we’ll contract the challenges and advantages of SaaS
+                            customers and vendors. In this talk we’ll contrast the challenges and advantages of SaaS
                             and on-prem, see how things have evolved in recent history, and see how modern on-prem
                             deployment can be, if not pleasurable, at least relatively painless.</p>
-
                     </small>
 
 
-                    <span
-                        style="text-transform: uppercase; color: white; font-size: 15px; font-weight: 400;"><strong>BIO:</strong>
+                    <span style="text-transform: uppercase; color: white; font-size: 15px; font-weight: 400;"><strong>BIO:</strong>
                         <p>A programming junkie and computer history aficionado, Tomer’s been an avid software
                             professional for almost two decades, during which he’s built any number of
                             (predominantly back-end) systems, cofounded two major Israeli user groups (Java.IL and
                             Underscore), organized an annual Scala conference (Scalapeño) and is a recurring speaker
                             at software conferences. Plying his trade as a gun-for-hire at Substrate, he secretly
                             still hopes to realize his childhood dream of becoming a lion tamer.
-
-                            Links:</p>
-                        <ul>
-                            <li>Linkedin: <a href="http://il.linkedin.com/in/tomergabel/"
-                                    target="_blank">http://il.linkedin.com/in/tomergabel/</a></li>
-                            <li>Lanyard: <a href="http://lanyrd.com/profile/tomergabel/"
-                                    target="_blank">http://lanyrd.com/profile/tomergabel/</a></li>
-                            <li> GitHub: <a href="https://github.com/holograph"
-                                    target="_blank">https://github.com/holograph</a></li>
-                            <li>Twitter: <a href="https://twitter.com/tomerg"
-                                    target="_blank">https://twitter.com/tomerg</a></li>
-                        </ul>
+                        </p>
                     </span>
                     <p></p>
 

--- a/_site/devopsdays/agenda-2021.html
+++ b/_site/devopsdays/agenda-2021.html
@@ -1882,10 +1882,9 @@
                             alone a decade or two: the same technologies that enable SaaS have also radically
                             transformed on-prem deployment. Modern tools like Docker, Consul, ELK and Kubernetes -
                             to name a few - can be leveraged to completely transform the experience for both
-                            customers and vendors. In this talk we’ll contract the challenges and advantages of SaaS
+                            customers and vendors. In this talk we’ll contrast the challenges and advantages of SaaS
                             and on-prem, see how things have evolved in recent history, and see how modern on-prem
                             deployment can be, if not pleasurable, at least relatively painless.</p>
-
                     </small>
 
 
@@ -1896,14 +1895,7 @@
                             Underscore), organized an annual Scala conference (Scalapeño) and is a recurring speaker
                             at software conferences. Plying his trade as a gun-for-hire at Substrate, he secretly
                             still hopes to realize his childhood dream of becoming a lion tamer.
-
-                            Links:</p>
-                        <ul>
-                            <li>Linkedin: <a href="http://il.linkedin.com/in/tomergabel/" target="_blank">http://il.linkedin.com/in/tomergabel/</a></li>
-                            <li>Lanyard: <a href="http://lanyrd.com/profile/tomergabel/" target="_blank">http://lanyrd.com/profile/tomergabel/</a></li>
-                            <li> GitHub: <a href="https://github.com/holograph" target="_blank">https://github.com/holograph</a></li>
-                            <li>Twitter: <a href="https://twitter.com/tomerg" target="_blank">https://twitter.com/tomerg</a></li>
-                        </ul>
+                        </p>
                     </span>
                     <p></p>
 


### PR DESCRIPTION
perform changes according to Tomer's request-
from his mail:
* "In this talk we’ll contract" -- there's a typo there, should've been "contrast". My bad.
* The bio was copy-pasted as-is, and contains a whole "LINKS:" section that just looks off (and is redundant given the social media icons are already present next to the avatar).