### PR TITLE
update site for current status

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -29,7 +29,7 @@
 
             <div class="content">
                 <span style="text-transform: uppercase;">
-                    <h2>DEVOPSDAYS TEL AVIV IS COMING BACK!</h2>
+                    <h2>DEVOPSDAYS Tel-Aviv is BACK - 24-25/11/2021!</h2>
                     <ul class="actions">
                         <li>Join us <strong>November 24-25th at Smolarz Auditorium, TAU</strong> for two awesome days! &nbsp; &nbsp;<a href="/devopsdays/register" class="button next scrolly" target="_blank">REGISTER</a></li>
                     </ul>

--- a/_site/devopsdays.html
+++ b/_site/devopsdays.html
@@ -126,16 +126,16 @@
 <!-- One -->
 <div class="inner">
     <div class="row">
-    <h2 style="text-transform: uppercase; color: turquoise;">DEVOPSDAYS tel aviv is COMING BACK in 2021!</h2>
+    <h2 style="text-transform: uppercase; color: turquoise;">DEVOPSDAYS Tel-Aviv is BACK - 24-25/11/2021!</h2>
         <div class="box" style="width: 100%; text-align: center;">
             <iframe width="100%" height="500" src="https://www.youtube.com/embed/i6w-rAmg84w" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>
             <br />
             <br />
-            <p>DevOpsDays Tel Aviv is coming back for its <span style="color: #d95374;">EIGHTH time</span> to bring some of the longest-running DevOps community events in Tel Aviv together into ONE AWESOME <span style="font-weight: 700; color: #c0d44f;">{in-person}</span> event.</p>
-            <p>DevOpsDays Tel Aviv is part of the global <a href="https://devopsdays.org/" target="_blank">devopsdays event series</a>, bringing in participants from the entire global devopsdays community.  To learn more, you can visit our event on the main <a href="https://devopsdays.org/events/2021-tel-aviv/welcome/" target="_blank">devopsdays.org</a> website.</p>
+            <p>DevOpsDays Tel-Aviv is back for its <span style="color: #d95374;">EIGHTH time</span> to bring some of the longest-running DevOps community events in Tel Aviv together into ONE AWESOME <span style="font-weight: 700; color: #c0d44f;">{in-person}</span> event.</p>
+            <p>DevOpsDays Tel-Aviv is part of the global <a href="https://devopsdays.org/" target="_blank">devopsdays event series</a>, bringing in participants from the entire global devopsdays community.  To learn more, you can visit our event on the main <a href="https://devopsdays.org/events/2021-tel-aviv/welcome/" target="_blank">devopsdays.org</a> website.</p>
             <p style="text-align: left; ">Join leading industry speakers along with DevOps, SRE, platform, production and operations engineers for two full days of sessions focusing on best practices in modern  engineering - from the infrastructure and operations to the systems and processes. DevOpsDays is a volunteer-led event, by the community for the community, with talks contributed by some of the best from our local community as well as the global DevOps community, with a variety of talks from beginner through advanced levels, so literally anyone can join and enjoy the sessions.</p>
 
-            <p style="text-align: center; font-weight: 700; color: #c0d44f;">Join us for a single-track DevOpsDays with a dedicated track for Cloud Native &amp; OSS Day and Statscraft each day. </p>
+            <p style="text-align: center; font-weight: 700; color: #c0d44f;">Join us for a single-track DevOpsDays with a dedicated track for Cloud Native &amp; OSS Day / Statscraft each day. </p>
 
             <span style="text-align: center;">
             <img src="/assets/images/statscraft-SQ.png" width="250" />&nbsp; &nbsp; <img src="/assets/images/cloudnative-SQ.png" width="250" />

--- a/_site/devopsdays/register.html
+++ b/_site/devopsdays/register.html
@@ -133,7 +133,7 @@
 
         <div class="box" style="width: 100%; text-align: center;">
          
-            <p>DevOpsDays Tel Aviv is back for its <span style="color: #d95374;">EIGHTH time</span> to bring some of the longest-running DevOps community events in Tel Aviv together into ONE AWESOME <span style="font-weight: 700; color: #c0d44f;">{in-person}</span> event.</p>
+            <p>DevOpsDays Tel-Aviv is back for its <span style="color: #d95374;">EIGHTH time</span> to bring some of the longest-running DevOps community events in Tel Aviv together into ONE AWESOME <span style="font-weight: 700; color: #c0d44f;">{in-person}</span> event.</p>
             <p>DevOpsDays Tel Aviv is part of the global <a href="https://devopsdays.org/" target="_blank">devopsdays event series</a>, bringing in participants from the entire global devopsdays community.  To learn more, you can visit our event on the main <a href="https://devopsdays.org/events/2021-tel-aviv/welcome/" target="_blank">devopsdays.org</a> website.</p>
             <p style="text-align: left; ">Join leading industry speakers along with DevOps, SRE, platform, production and operations engineers for two full days of sessions focusing on best practices in modern  engineering - from the infrastructure and operations to the systems and processes. DevOpsDays is a volunteer-led event, by the community for the community, with talks contributed by some of the best from our local community as well as the global DevOps community, with a variety of talks from beginner through advanced levels, so literally anyone can join and enjoy the sessions.</p>
 
@@ -165,7 +165,7 @@
                 <br />
                 <br />
 
-                <ul class="actions"><li><a href="https://www.eventbrite.com/e/devopsdays-tel-aviv-2021-with-cloud-native-oss-day-statscraft-tickets-163006999323" target="_blank" class="button fit">REGISTER ON EVENTBRITE</a></li></ul>
+                <!-- <ul class="actions"><li><a href="https://www.eventbrite.com/e/devopsdays-tel-aviv-2021-with-cloud-native-oss-day-statscraft-tickets-163006999323" target="_blank" class="button fit">REGISTER ON EVENTBRITE</a></li></ul> -->
 
                 <ul class="actions"><li><a href="/devopsdays/agenda-2021" target="_blank" class="button special fit">VIEW EVENT PROGRAM </a></li></ul> 
 

--- a/_site/index.html
+++ b/_site/index.html
@@ -119,7 +119,7 @@
 
             <div class="content">
                 <span style="text-transform: uppercase;">
-                    <h2>DEVOPSDAYS TEL AVIV IS COMING BACK!</h2>
+                    <h2>DEVOPSDAYS Tel-Aviv is BACK - 24-25/11/2021!</h2>
                     <ul class="actions">
                         <li>Join us <strong>November 24-25th at Smolarz Auditorium, TAU</strong> for two awesome days! &nbsp; &nbsp;<a href="/devopsdays/register" class="button next scrolly" target="_blank">REGISTER</a></li>
                     </ul>

--- a/devopsdays.md
+++ b/devopsdays.md
@@ -14,16 +14,16 @@ nav-menu: true
 <!-- One -->
 <div class="inner">
     <div class="row">
-    <h2 style="text-transform: uppercase; color: turquoise;">DEVOPSDAYS tel aviv is COMING BACK in 2021!</h2>
+    <h2 style="text-transform: uppercase; color: turquoise;">DEVOPSDAYS Tel-Aviv is BACK - 24-25/11/2021!</h2>
         <div class="box" style="width: 100%; text-align: center;">
             <iframe width="100%" height="500" src="https://www.youtube.com/embed/i6w-rAmg84w" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
             <br/>
             <br/>
-            <p>DevOpsDays Tel Aviv is coming back for its <span style="color: #d95374;">EIGHTH time</span> to bring some of the longest-running DevOps community events in Tel Aviv together into ONE AWESOME <span style="font-weight: 700; color: #c0d44f;">{in-person}</span> event.</p>
+            <p>DevOpsDays Tel-Aviv is back for its <span style="color: #d95374;">EIGHTH time</span> to bring some of the longest-running DevOps community events in Tel Aviv together into ONE AWESOME <span style="font-weight: 700; color: #c0d44f;">{in-person}</span> event.</p>
             <p>DevOpsDays Tel Aviv is part of the global <a href="https://devopsdays.org/" target="_blank">devopsdays event series</a>, bringing in participants from the entire global devopsdays community.  To learn more, you can visit our event on the main <a href="https://devopsdays.org/events/2021-tel-aviv/welcome/" target="_blank">devopsdays.org</a> website.</p>
             <p style="text-align: left; ">Join leading industry speakers along with DevOps, SRE, platform, production and operations engineers for two full days of sessions focusing on best practices in modern  engineering - from the infrastructure and operations to the systems and processes. DevOpsDays is a volunteer-led event, by the community for the community, with talks contributed by some of the best from our local community as well as the global DevOps community, with a variety of talks from beginner through advanced levels, so literally anyone can join and enjoy the sessions.</p>
 
-            <p style="text-align: center; font-weight: 700; color: #c0d44f;">Join us for a single-track DevOpsDays with a dedicated track for Cloud Native & OSS Day and Statscraft each day. </p>
+            <p style="text-align: center; font-weight: 700; color: #c0d44f;">Join us for a single-track DevOpsDays with a dedicated track for Cloud Native & OSS Day / Statscraft each day. </p>
 
             <span style="text-align: center;">
             <img src="/assets/images/statscraft-SQ.png" width="250">&nbsp; &nbsp; <img src="/assets/images/cloudnative-SQ.png" width="250">

--- a/devopsdays/register.md
+++ b/devopsdays/register.md
@@ -21,7 +21,7 @@ nav-menu: true
 
         <div class="box" style="width: 100%; text-align: center;">
          
-            <p>DevOpsDays Tel Aviv is coming back for its <span style="color: #d95374;">EIGHTH time</span> to bring some of the longest-running DevOps community events in Tel Aviv together into ONE AWESOME <span style="font-weight: 700; color: #c0d44f;">{in-person}</span> event.</p>
+            <p>DevOpsDays Tel-Aviv is back for its <span style="color: #d95374;">EIGHTH time</span> to bring some of the longest-running DevOps community events in Tel Aviv together into ONE AWESOME <span style="font-weight: 700; color: #c0d44f;">{in-person}</span> event.</p>
             <p>DevOpsDays Tel Aviv is part of the global <a href="https://devopsdays.org/" target="_blank">devopsdays event series</a>, bringing in participants from the entire global devopsdays community.  To learn more, you can visit our event on the main <a href="https://devopsdays.org/events/2021-tel-aviv/welcome/" target="_blank">devopsdays.org</a> website.</p>
             <p style="text-align: left; ">Join leading industry speakers along with DevOps, SRE, platform, production and operations engineers for two full days of sessions focusing on best practices in modern  engineering - from the infrastructure and operations to the systems and processes. DevOpsDays is a volunteer-led event, by the community for the community, with talks contributed by some of the best from our local community as well as the global DevOps community, with a variety of talks from beginner through advanced levels, so literally anyone can join and enjoy the sessions.</p>
 
@@ -33,7 +33,7 @@ nav-menu: true
                 <br/>
                 <br/>
 
-                <ul class="actions"><li><a href="https://www.eventbrite.com/e/devopsdays-tel-aviv-2021-with-cloud-native-oss-day-statscraft-tickets-163006999323" target="_blank" class="button fit">REGISTER ON EVENTBRITE</a></li></ul>
+                <!-- <ul class="actions"><li><a href="https://www.eventbrite.com/e/devopsdays-tel-aviv-2021-with-cloud-native-oss-day-statscraft-tickets-163006999323" target="_blank" class="button fit">REGISTER ON EVENTBRITE</a></li></ul> -->
 
                 <ul class="actions"><li><a href="/devopsdays/agenda-2021" target="_blank" class="button special fit">VIEW EVENT PROGRAM </a></li></ul> 
 


### PR DESCRIPTION
update site - devopsdays is back, instead of coming back. remove register on eventbrite since we are sold out